### PR TITLE
Genaktiver CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install 'black' code format checker
+          name: Install 'black' code format checker and pytest
           command: |
             source /opt/conda/bin/activate fikspunktsregister
-            conda install -c conda-forge black
+            conda install -c conda-forge black pytest
       - run:
           name: Run 'black' code format check. If this fails you have not run 'black' on the failing files.
           command: |
@@ -60,4 +60,5 @@ jobs:
           name: Run tests
           command: |
             source /opt/conda/bin/activate fikspunktsregister
+
             ORA_USER=fire ORA_PASSWORD=fire ORA_HOST=localhost pytest


### PR DESCRIPTION
Vi skal som minimum bruge Oracle 12c hvilket ikke findes i et let tilgængelig Travis setup, så derfor genopliver jeg CircleCI. Det er ikke perfekt da de to docker images der benyttes er nogle sorte bokse vi ikke har ordentligt indsigt i. Forhåbentligt er der på et tidspunkt en der gider lave et Travis setup der bruger en nyere Oracle version.