### PR TITLE
Opdater DDL med KOORDINAT.ARTSKODE kolonne

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
       - run:
           name: Install 'black' code format checker and pytest
           command: |
-            source /opt/conda/bin/activate fikspunktsregister
-            conda install -c conda-forge black pytest
+            source /opt/conda/bin/activate base
+            conda env create -f environment-dev.yml
       - run:
           name: Run 'black' code format check. If this fails you have not run 'black' on the failing files.
           command: |
-            source /opt/conda/bin/activate fikspunktsregister
+            source /opt/conda/bin/activate fikspunktsregister-dev
             black --check ./
       - run:
           name: Sleep 15 seconds to allow Oracle DB to ready itself
@@ -30,6 +30,6 @@ jobs:
       - run:
           name: Run tests
           command: |
-            source /opt/conda/bin/activate fikspunktsregister
+            source /opt/conda/bin/activate fikspunktsregister-dev
 
             ORA_USER=fire ORA_PASSWORD=fire ORA_HOST=localhost pytest

--- a/fireapi/model/__init__.py
+++ b/fireapi/model/__init__.py
@@ -4,6 +4,22 @@ import sqlalchemy.ext.declarative
 from sqlalchemy import Column, Integer, DateTime, func
 
 
+class IntEnum(sqlalchemy.types.TypeDecorator):
+    """Add an integer enum class"""
+
+    impl = sqlalchemy.Integer
+
+    def __init__(self, enumtype, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enumtype = enumtype
+
+    def process_bind_param(self, value, dialect):
+        return value.value
+
+    def process_result_value(self, value, dialect):
+        return self._enumtype(value)
+
+
 class ReprBase(object):
     """Extend the base class
     Provides a nicer representation when a class instance is printed.

--- a/fireapi/model/punkttyper.py
+++ b/fireapi/model/punkttyper.py
@@ -4,13 +4,14 @@ from sqlalchemy.orm import relationship
 
 # DeclarativeBase = sqlalchemy.ext.declarative.declarative_base(cls=ReprBase)
 
-from fireapi.model import RegisteringTidObjekt, DeclarativeBase, columntypes
+from fireapi.model import IntEnum, RegisteringTidObjekt, DeclarativeBase, columntypes
 
 # Eksports
 __all__ = [
     "FikspunktregisterObjekt",
     "Punkt",
     "Koordinat",
+    "Artskode",
     "GeometriObjekt",
     "Beregning",
     "ObservationType",
@@ -26,6 +27,33 @@ class PunktInformationTypeAnvendelse(enum.Enum):
     FLAG = "FLAG"
     TAL = "TAL"
     TEKST = "TEKST"
+
+
+class Artskode(enum.Enum):
+    """
+    Uddybende beskrivelser fra REFGEO:
+
+    artskode = 1 control point in fundamental network, first order.
+    artskode = 2 control point in superior plane network.
+    artskode = 2 control point in superior height network.
+    artskode = 3 control point in network of high quality.
+    artskode = 4 control point in network of lower or unknown quality.
+    artskode = 5 coordinate computed on just a few measurements.
+    artskode = 6 coordinate transformed from local or an not valid coordinate system.
+    artskode = 7 coordinate computed on an not valid coordinate system, or system of unknown origin.
+    artskode = 8 coordinate computed on few measurements, and on an not valid coordinate system.
+    artskode = 9 location coordinate or location height.
+    """
+
+    FUNDAMENTAL_PUNKT = 1
+    NETVAERK_AF_GOD_KVALITET = 2
+    NETVAERK_AF_HOEJ_KVALITET = 3
+    NETVAERK_AF_LAV_KVALITET = 4
+    BESTEMT_FRA_FAA_OBSERVATIONER = 5
+    TRANSFORMERET = 6
+    UKENDT_KOORDINATSYSTEM = 7
+    FAA_OBS_OG_UKENDT_KOORDINATSYSTEM = 8
+    LOKATIONSKOORDINAT = 9
 
 
 beregning_koordinat = Table(
@@ -120,6 +148,7 @@ class Koordinat(FikspunktregisterObjekt):
     sz = Column(Float)
     t = Column(DateTime(timezone=True))
     transformeret = Column(String, nullable=False)
+    artskode = Column(IntEnum(Artskode), default=Artskode.NETVAERK_AF_LAV_KVALITET)
     x = Column(Float)
     y = Column(Float)
     z = Column(Float)

--- a/test/fixtures/sql/fikspunkt_forvaltning.sql
+++ b/test/fixtures/sql/fikspunkt_forvaltning.sql
@@ -53,6 +53,7 @@ CREATE TABLE KOORDINAT (
    SZ NUMBER,
    T TIMESTAMP WITH TIME ZONE,
    TRANSFORMERET VARCHAR2(5) NOT NULL,
+   ARTSKODE INTEGER,
    X NUMBER,
    Y NUMBER,
    Z NUMBER,
@@ -269,6 +270,20 @@ COMMENT ON COLUMN KOORDINAT.SY IS 'A posteriori spredning på andenkoordinaten.'
 COMMENT ON COLUMN KOORDINAT.SZ IS 'A posteriori spredning på tredjekoordinaten.';
 COMMENT ON COLUMN KOORDINAT.T IS 'Observationstidspunktet.';
 COMMENT ON COLUMN KOORDINAT.TRANSFORMERET IS 'Angivelse om positionen er målt, eller transformeret fra et andet koordinatsystem';
+COMMENT ON COLUMN KOORDINAT.ARTSKODE IS 'Fra REFGEO. Værdierne skal forstås som følger:
+
+ artskode = 1 control point in fundamental network, first order.
+ artskode = 2 control point in superior plane network.
+ artskode = 2 control point in superior height network.
+ artskode = 3 control point in network of high quality.
+ artskode = 4 control point in network of lower or unknown quality.
+ artskode = 5 coordinate computed on just a few measurements.
+ artskode = 6 coordinate transformed from local or an not valid coordinate system.
+ artskode = 7 coordinate computed on an not valid coordinate system, or system of unknown origin.
+ artskode = 8 coordinate computed on few measurements, and on an not valid coordinate system.
+ artskode = 9 location coordinate or location height.
+ 
+ Artskode er kun tilgængelig for koordinater der stammer fra REFGEO.';
 COMMENT ON COLUMN KOORDINAT.X IS 'Førstekoordinat.';
 COMMENT ON COLUMN KOORDINAT.Y IS 'Andenkoordinat.';
 COMMENT ON COLUMN KOORDINAT.Z IS 'Tredjekoordinat.';
@@ -724,7 +739,6 @@ end;
 /
 
 
-
 CREATE OR REPLACE TRIGGER AUD#PUNKT
 after update ON PUNKT
 for each row
@@ -1110,4 +1124,4 @@ VALUES ('bruges når nye koordinater skabes. Knytter observationer til koordinat
 INSERT INTO EVENTTYPE (BESKRIVELSE, EVENT, EVENTTYPEID)
 VALUES ('bruges til at tilføje fritekst kommentarer til sagen i tilfælde af at der er behov for at påhæfte sagen yderligere information som ikke passer i andre hændelser. Bruges fx også til påhæftning af materiale på sagen.', 'kommentar', 10);
 
--- End
+-- End

--- a/test/test_koordinat.py
+++ b/test/test_koordinat.py
@@ -1,6 +1,11 @@
 from fireapi import FireDb
-from fireapi.model import Koordinat
+from fireapi.model import Koordinat, Artskode
 
 
 def test_koordinat(firedb: FireDb, koordinat: Koordinat):
+    firedb.session.commit()
+
+
+def test_artskode(firedb: FireDb, koordinat: Koordinat):
+    koordinat.artskode = Artskode.TRANSFORMERET
     firedb.session.commit()


### PR DESCRIPTION
Tilpas API som konsekvens. 'artskode' er en efterladenskab
fra REFGEO som vi ikke vil eksponere via API'et, derfor er kolonnen
markeret som "excluded property".

So far bare en test af om det går godt at tilføje artskoden på denne måde. Merges først når DDL er opdateret i FIRE-DDL repositoriet.